### PR TITLE
Install safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ After run the command, your goimports will become fast :dizzy:
 
 new `goimports` have stdlib and all GOPATH's libs mappings, it's very fast.
 
+**Note:** It supports `.goimportsignore` and ignores `vendor/` directory.
+
 ## Return to the original goimports
 
 You can return to the original goimports by the following:
 
 ```sh
-$ cd $GOPATH/src/golang.org/x/tools
-$ git checkout imports/zstdlib.go
 $ cd $GOPATH/src/golang.org/x/tools/cmd/goimports
 $ go install -a .
 ```
@@ -46,7 +46,6 @@ $ go get github.com/monochromegane/dragon-imports/...
 ## ToDo
 
 - File system notification.
-- Ignore option.
 
 ## Contribution
 

--- a/install.go
+++ b/install.go
@@ -4,7 +4,26 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
+
+func installUsing(f *os.File) error {
+	current := filepath.Join(outPath(), "zstdlib.go")
+	backup := strings.Replace(current, ".go", ".g_", 1)
+
+	err := os.Rename(current, backup)
+	if err != nil {
+		return err
+	}
+	defer os.Rename(backup, current)
+
+	err = os.Rename(f.Name(), current)
+	if err != nil {
+		return err
+	}
+
+	return install()
+}
 
 func install() error {
 	cmd := exec.Command("go", "install", "-a", ".")

--- a/out.go
+++ b/out.go
@@ -10,15 +10,6 @@ import (
 	"sort"
 )
 
-func updateZstdlib(libChan chan lib) error {
-	f, err := os.OpenFile(filepath.Join(outPath(), "zstdlib.go"), os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return out(libChan, f)
-}
-
 func out(libChan chan lib, w io.Writer) error {
 	libs := map[string]lib{}
 	ambiguous := map[string]bool{}


### PR DESCRIPTION
Now, dragon-imports overwrites original `zstdlib.go`.
So, from now on, it replaces to new `zstdlib.go` only when installing.
Also, the original source is restored.