### PR TITLE
support Go1.11 and later

### DIFF
--- a/file_info.go
+++ b/file_info.go
@@ -13,10 +13,8 @@ type fileInfo struct {
 
 func (f fileInfo) isDir(follow bool) bool {
 	if follow && f.isSymlink() {
-		if _, err := ioutil.ReadDir(filepath.Join(f.path, f.FileInfo.Name())); err == nil {
-			return true
-		}
-		return false
+		_, err := ioutil.ReadDir(filepath.Join(f.path, f.FileInfo.Name()))
+		return err == nil
 	}
 	return f.FileInfo.IsDir()
 }

--- a/gopath_libs.go
+++ b/gopath_libs.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 )
 
-func fetchGoImportsIgnore(src string) (map[string]struct{}, error) {
-	dirs := make(map[string]struct{})
+func fetchGoImportsIgnore(src string) (map[string]bool, error) {
+	dirs := make(map[string]bool)
 	f, err := os.Open(filepath.Join(src, ".goimportsignore"))
 	if err != nil {
 		return dirs, nil
@@ -20,13 +20,13 @@ func fetchGoImportsIgnore(src string) (map[string]struct{}, error) {
 	for scr.Scan() {
 		dir := scr.Text()
 		if !strings.HasPrefix(dir, "#") {
-			dirs[filepath.Join(src, dir)] = struct{}{}
+			dirs[filepath.Join(src, dir)] = true
 		}
 	}
 	return dirs, scr.Err()
 }
 
-func isSkipDir(fi fileInfo, ignoreDirs map[string]struct{}) bool {
+func isSkipDir(fi fileInfo, ignoreDirs map[string]bool) bool {
 	name := fi.Name()
 	switch name {
 	case "", "testdata", "vendor":
@@ -36,8 +36,7 @@ func isSkipDir(fi fileInfo, ignoreDirs map[string]struct{}) bool {
 	case '.', '_':
 		return true
 	}
-	_, ok := ignoreDirs[filepath.Join(fi.path, fi.Name())]
-	return ok
+	return ignoreDirs[filepath.Join(fi.path, fi.Name())]
 }
 
 func gopathLibs(libChan chan lib) error {

--- a/std_libs.go
+++ b/std_libs.go
@@ -12,28 +12,16 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	apiFiles = [...]string{
-		"go1.txt",
-		"go1.1.txt",
-		"go1.2.txt",
-		"go1.3.txt",
-		"go1.4.txt",
-		"go1.5.txt",
-		"go1.6.txt",
-		"go1.7.txt",
-		"go1.8.txt",
-		"go1.9.txt",
-		"go1.10.txt",
-	}
-	sym = regexp.MustCompile(`^pkg (\S+).*?, (?:var|func|type|const) ([A-Z]\w*)`)
-)
+var sym = regexp.MustCompile(`^pkg (\S+).*?, (?:var|func|type|const) ([A-Z]\w*)`)
 
 func stdLibs(libChan chan lib) error {
-	apiDir := filepath.Join(build.Default.GOROOT, "api")
+	apiFiles, err := filepath.Glob(filepath.Join(build.Default.GOROOT, "api", "go1.*txt"))
+	if err != nil {
+		return err
+	}
 	eg := &errgroup.Group{}
 	for _, f := range apiFiles {
-		r, err := os.Open(filepath.Join(apiDir, f))
+		r, err := os.Open(f)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Go1.11 is out and we should add "go1.11.txt" to `apiFiles` slice. This is little a bit bothering work.

So, How about retrieve API files by using glob? It is slightly rough, but it will work almost correctly.