### PR TITLE
zstdlib.go which is generated by dragon-imports does not contain duplicated symbols.

### DIFF
--- a/dragon.go
+++ b/dragon.go
@@ -53,7 +53,6 @@ func Imports() error {
 }
 
 type lib struct {
-	pkg    string
 	object string
 	path   string
 }

--- a/gopath_libs.go
+++ b/gopath_libs.go
@@ -79,7 +79,6 @@ func gopathLibs(libChan chan lib) error {
 			for _, v := range f.Scope.Objects {
 				if ast.IsExported(v.Name) {
 					libChan <- lib{
-						pkg:    pkg,
 						object: v.Name,
 						path:   importPath,
 					}

--- a/out.go
+++ b/out.go
@@ -8,20 +8,6 @@ import (
 )
 
 func out(libChan chan lib, w io.Writer) error {
-	libs := map[string]lib{}
-	ambiguous := map[string]bool{}
-	for lib := range libChan {
-		full := lib.path
-		key := lib.pkg + "." + lib.object
-		if exist, ok := libs[key]; ok {
-			if exist.path != full {
-				ambiguous[key] = true
-			}
-		} else {
-			libs[key] = lib
-		}
-	}
-
 	stdlib := map[string]map[string]bool{
 		"unsafe": map[string]bool{
 			"Alignof":       true,
@@ -31,10 +17,7 @@ func out(libChan chan lib, w io.Writer) error {
 			"Sizeof":        true,
 		},
 	}
-	for key, lib := range libs {
-		if ambiguous[key] {
-			continue
-		}
+	for lib := range libChan {
 		objMap, ok := stdlib[lib.path]
 		if !ok {
 			objMap = make(map[string]bool)

--- a/out_test.go
+++ b/out_test.go
@@ -11,9 +11,12 @@ func TestOut(t *testing.T) {
 
 	go func() {
 		libChan <- lib{
-			pkg:    "dragon",
 			object: "Imports",
 			path:   "github.com/monochromegane/dragon-imports",
+		}
+		libChan <- lib{
+			object: "Imports",
+			path:   "github.com/someone/dragon-imports",
 		}
 		close(libChan)
 	}()
@@ -34,6 +37,7 @@ var stdlib = map[string]map[string]bool{`
 
 	contains := []string{
 		`"github.com/monochromegane/dragon-imports":map[string]bool{"Imports":true}`,
+		`"github.com/someone/dragon-imports":map[string]bool{"Imports":true}`,
 		`"unsafe":map[string]bool{`,
 	}
 

--- a/std_libs.go
+++ b/std_libs.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"go/build"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -36,7 +35,6 @@ func stdLibs(libChan chan lib) error {
 
 				if m := sym.FindStringSubmatch(l); m != nil {
 					libChan <- lib{
-						pkg:    path.Base(m[1]),
 						object: m[2],
 						path:   m[1],
 					}


### PR DESCRIPTION
## What is happening?

Original text as follows.

```go
package dragon

func hoge() {
        rand.Int()
}
```

Run goimports which is installed by dragon-imports

```go
package dragon

import (
        "golang.org/x/exp/rand"
)

func hoge() {
        rand.Int()
}
```

I expect as follows.

```go
package dragon

import (
        "crypto/rand"
)

func hoge() {
        rand.Int()
}
```

## Why

Currently, dragon-imports use a key for detecting ambiguous symbols.
For example, the key "rand.Int" duplicate from "math/rand" and "crypto/rand".
Currently, skipping the ambiguous symbols using the key, dragon-imports cannot contain both symbols.
Thus, goimports find symbols from GOPATH.

But, current imports package use a package path as the key (math/rand, crypto/rand).
And, the key is also used for detecting ambiguous one.

## How to fix

I use the same key in this tool, remove broken code which detect ambiguous symbols.
This behaivor is same as original zstdlib.go.