### PR TITLE
Add restore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ new `goimports` have stdlib and all GOPATH's libs mappings, it's very fast.
 You can return to the original goimports by the following:
 
 ```sh
-$ cd $GOPATH/src/golang.org/x/tools/cmd/goimports
-$ go install -a .
+$ dragon-imports --restore
 ```
 
 ## Installation

--- a/cmd/dragon-imports/main.go
+++ b/cmd/dragon-imports/main.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 
-	"github.com/monochromegane/dragon-imports"
+	dragon "github.com/monochromegane/dragon-imports"
 )
 
+var restore bool
+
+func init() {
+	flag.BoolVar(&restore, "restore", false, "goimports is returned to original one.")
+}
+
 func main() {
-	err := dragon.Imports()
+	flag.Parse()
+	err := dragon.Imports(restore)
 	if err != nil {
 		log.Fatal(err)
 		os.Exit(1)

--- a/dragon.go
+++ b/dragon.go
@@ -9,9 +9,12 @@ import (
 )
 
 // Imports generate zstdlib.go from api files and libs in GOPATH.
-func Imports() error {
+func Imports(restore bool) error {
 	if !existGoImports() {
 		return errors.New("goimports command isn't installed")
+	}
+	if restore {
+		return install()
 	}
 
 	libChan := make(chan lib, 1000)


### PR DESCRIPTION
dragon-imports returns zstdlib.go to original after `go install -a .`.
ref: https://github.com/monochromegane/dragon-imports/pull/3

Because we always have original zstdlib.go, we can return goimports command to original as follows.

```sh
cd $GOPATH/src/golang.org/x/tools/cmd/goimports
go install -a .
```

But remembering the correct path is hard, so this operation will be wrapped using dragon-imports.
