### PR TITLE
Support Go modules (Currently it is experimental feature)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
   - 1.11.x
-  - release
   - tip
 script:
   - go test -v ./...

--- a/cmd/dragon-imports/main.go
+++ b/cmd/dragon-imports/main.go
@@ -8,15 +8,19 @@ import (
 	dragon "github.com/monochromegane/dragon-imports"
 )
 
-var restore bool
+var (
+	restore   bool
+	gomodules bool
+)
 
 func init() {
 	flag.BoolVar(&restore, "restore", false, "goimports is returned to original one.")
+	flag.BoolVar(&gomodules, "gomodules", false, "goimports makes zstdlib.go from Go modules packages instead of GOPATH/src.")
 }
 
 func main() {
 	flag.Parse()
-	err := dragon.Imports(restore)
+	err := dragon.Imports(restore, gomodules)
 	if err != nil {
 		log.Fatal(err)
 		os.Exit(1)

--- a/dir.go
+++ b/dir.go
@@ -6,11 +6,19 @@ import (
 )
 
 func srcDirs() []string {
+	return dirs("src")
+}
+
+func modDirs() []string {
+	return dirs(filepath.Join("pkg", "mod"))
+}
+
+func dirs(path string) []string {
 	gopaths := filepath.SplitList(build.Default.GOPATH)
 
-	srcDirs := make([]string, len(gopaths))
+	dirs := make([]string, len(gopaths))
 	for i, gopath := range gopaths {
-		srcDirs[i] = filepath.Join(gopath, "src")
+		dirs[i] = filepath.Join(gopath, path)
 	}
-	return srcDirs
+	return dirs
 }

--- a/dragon.go
+++ b/dragon.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Imports generate zstdlib.go from api files and libs in GOPATH.
-func Imports(restore bool) error {
+func Imports(restore, gomodules bool) error {
 	if !existGoImports() {
 		return errors.New("goimports command isn't installed")
 	}
@@ -37,7 +37,11 @@ func Imports(restore bool) error {
 		return stdLibs(libChan)
 	})
 	eg.Go(func() error {
-		return gopathLibs(libChan)
+		if gomodules {
+			return gomoduleLibs(libChan)
+		} else {
+			return gopathLibs(libChan)
+		}
 	})
 	if err := eg.Wait(); err != nil {
 		return err

--- a/gomodule_libs.go
+++ b/gomodule_libs.go
@@ -1,0 +1,132 @@
+package dragon
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+type mod struct {
+	version string
+	lib     lib
+}
+
+var regPath = regexp.MustCompile("@v[0-9]+\\.[0-9]+\\.[0-9].*?(/|$)")
+
+func extractImportPathAndVersion(path string) (string, string) {
+	version := regPath.FindString(path)
+	importPath := regPath.ReplaceAllString(path, "/")
+	return strings.TrimSuffix(importPath, "/"), strings.Trim(version, "@/")
+}
+
+type versions struct {
+	libByVersion map[string][]lib
+}
+
+func (v *versions) append(version string, l lib) {
+	v.libByVersion[version] = append(v.libByVersion[version], l)
+}
+
+func (v *versions) latest() []lib {
+	var versions semver.Versions
+	for version, _ := range v.libByVersion {
+		sv, err := semver.ParseTolerant(version)
+		if err != nil {
+			continue
+		}
+		versions = append(versions, sv)
+	}
+	semver.Sort(versions)
+
+	latest := versions[len(versions)-1]
+	if libs, ok := v.libByVersion["v"+latest.String()]; ok {
+		return libs
+	}
+	return []lib{}
+}
+
+func gomoduleLibs(libChan chan lib) error {
+	modChan := make(chan mod, 1000)
+	done := make(chan bool)
+
+	go func() {
+		modules := map[string]*versions{}
+		for mod := range modChan {
+			vs, ok := modules[mod.lib.path]
+			if !ok {
+				vs = &versions{libByVersion: map[string][]lib{}}
+				modules[mod.lib.path] = vs
+			}
+			vs.append(mod.version, mod.lib)
+		}
+		for _, v := range modules {
+			for _, lib := range v.latest() {
+				libChan <- lib
+			}
+		}
+		done <- true
+	}()
+
+	for _, modDir := range modDirs() {
+		ignoreDirs, err := fetchGoImportsIgnore(modDir)
+		if err != nil {
+			return err
+		}
+		err = concurrentWalk(modDir, func(info fileInfo) error {
+			if info.isDir(false) {
+				if isSkipDir(info, ignoreDirs) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(info.Name(), "_test.go") {
+				return nil
+			}
+			if !strings.HasSuffix(info.Name(), ".go") {
+				return nil
+			}
+
+			path := info.path
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				return nil
+			}
+
+			pkg := f.Name.Name
+			if pkg == "main" {
+				return nil
+			}
+
+			importPath, err := filepath.Rel(modDir, filepath.Dir(path))
+			if err != nil {
+				return nil
+			}
+
+			importPath, version := extractImportPathAndVersion(importPath)
+			for _, v := range f.Scope.Objects {
+				if ast.IsExported(v.Name) {
+					modChan <- mod{
+						version: version,
+						lib: lib{
+							object: v.Name,
+							path:   importPath,
+						},
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	close(modChan)
+	<-done
+	return nil
+}

--- a/gomodule_libs_test.go
+++ b/gomodule_libs_test.go
@@ -1,0 +1,65 @@
+package dragon
+
+import "testing"
+
+func TestVersionsLatest(t *testing.T) {
+
+	expects := map[string]map[string][]lib{
+		"111": map[string][]lib{
+			"v1.0.1": []lib{lib{path: "p", object: "101"}, lib{path: "p", object: "101"}},
+			"v1.1.1": []lib{lib{path: "p", object: "111"}, lib{path: "p", object: "111"}},
+			"v1.0.0": []lib{lib{path: "p", object: "100"}, lib{path: "p", object: "100"}},
+		},
+		"2": map[string][]lib{
+			"v0.0.0-1": []lib{lib{path: "p", object: "1"}, lib{path: "p", object: "1"}},
+			"v0.0.0-2": []lib{lib{path: "p", object: "2"}, lib{path: "p", object: "2"}},
+			"v0.0.0-0": []lib{lib{path: "p", object: "0"}, lib{path: "p", object: "0"}},
+		},
+	}
+
+	for expect, v := range expects {
+		versions := &versions{libByVersion: map[string][]lib{}}
+		for version, libs := range v {
+			for _, lib := range libs {
+				versions.append(version, lib)
+			}
+		}
+		libs := versions.latest()
+		for _, lib := range libs {
+			if lib.object != expect {
+				t.Errorf("versions.latest should return latest libs")
+			}
+		}
+	}
+}
+
+func TestExtractImportPathAndVersion(t *testing.T) {
+	expects := map[string][]string{
+		"golang.org/x/net@v0.0.0-20190125091013-d26f9f9a57f3/nettest": []string{
+			"golang.org/x/net/nettest",
+			"v0.0.0-20190125091013-d26f9f9a57f3",
+		},
+		"golang.org/x/tools@v0.0.0-20190201231825-51e363b66d25/godoc/dl": []string{
+			"golang.org/x/tools/godoc/dl",
+			"v0.0.0-20190201231825-51e363b66d25",
+		},
+		"github.com/donvito/hellomod/v2@v2.0.0": []string{
+			"github.com/donvito/hellomod/v2",
+			"v2.0.0",
+		},
+		"github.com/donvito/hellomod/v2@v2.0.0-alpha.1.beta": []string{
+			"github.com/donvito/hellomod/v2",
+			"v2.0.0-alpha.1.beta",
+		},
+	}
+
+	for path, expect := range expects {
+		importPath, version := extractImportPathAndVersion(path)
+		if importPath != expect[0] {
+			t.Errorf("extractImportPathAndVersion should return import path %s, but %s", expect[0], importPath)
+		}
+		if version != expect[1] {
+			t.Errorf("extractImportPathAndVersion should return version %s, but %s", expect[1], version)
+		}
+	}
+}

--- a/gopath_libs.go
+++ b/gopath_libs.go
@@ -29,7 +29,7 @@ func fetchGoImportsIgnore(src string) (map[string]bool, error) {
 func isSkipDir(fi fileInfo, ignoreDirs map[string]bool) bool {
 	name := fi.Name()
 	switch name {
-	case "", "internal", "testdata", "vendor":
+	case "", "internal", "testdata", "vendor", "cache":
 		return true
 	}
 	switch name[0] {


### PR DESCRIPTION
## What is happening?

goimports generated by dragon-imports slowly fixes imports when GO111MOODULES=on.

## Why

Currently, dragon-imports is not support Go modules.
In modules mode, Go puts package to $GOPATH/pkg/mod instead of $GOPATH/src that dragon-imports parses packages from.

## How to fix

I add gomodule option.
dragon-imports parses package from $GOPATH/pkg/mod, and add them to zstdlib.go.
dragon-imports use latest minor and patch version for parsing symbols in the same major version.
And it treats other major versions as another package.

Currently (Go 1.11), Go modules is optional feature. So, the option is also disable by default.

