### PR TITLE
use semi official semver package instead of blang/semver

### DIFF
--- a/gomodule_libs.go
+++ b/gomodule_libs.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/blang/semver"
+	"golang.org/x/mod/semver"
 )
 
 type mod struct {
@@ -33,18 +33,11 @@ func (v *versions) append(version string, l lib) {
 }
 
 func (v *versions) latest() []lib {
-	var versions semver.Versions
+	var latestVer string
 	for version, _ := range v.libByVersion {
-		sv, err := semver.ParseTolerant(version)
-		if err != nil {
-			continue
-		}
-		versions = append(versions, sv)
+		latestVer = semver.Max(latestVer, version)
 	}
-	semver.Sort(versions)
-
-	latest := versions[len(versions)-1]
-	if libs, ok := v.libByVersion["v"+latest.String()]; ok {
+	if libs, ok := v.libByVersion[latestVer]; ok {
 		return libs
 	}
 	return []lib{}


### PR DESCRIPTION
blang/semver is a bit broken, which is why the test of #12 is failed. I sent a patch to blang/semver but no response. (https://github.com/blang/semver/pull/56)
Recently, the semi-official semver package was added, so I switched to that.